### PR TITLE
Example failed because getScrollOffset() was set to private

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -1083,7 +1083,7 @@ pub fn getElementId(string: []const u8) ElementId {
 }
 
 // TODO: doc
-fn getScrollOffset() Vector2 {
+pub fn getScrollOffset() Vector2 {
     return cdefs.Clay_GetScrollOffset();
 }
 


### PR DESCRIPTION
I'm not sure if this function is intended to be public but it was the only fix I could find