### PR TITLE
Change Color from array of 4 f32 to 4 of u8.

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -110,7 +110,12 @@ pub const Vector2 = extern struct {
 
 /// Represents an RGBA color where components are in 0-255 range
 /// order: r, g, b, a
-pub const Color = [4]f32;
+pub const Color = packed struct {
+    r: u8,
+    g: u8,
+    b: u8,
+    a: u8,
+};
 
 pub const BoundingBox = extern struct {
     /// X coordinate of the top-left corner


### PR DESCRIPTION
Changing the Color type from array of 4 f32 to 4 u8 named fields.
From:
```zig
/// Represents an RGBA color where components are in 0-255 range
/// order: r, g, b, a
pub const Color = [4]f32;
```
To:
```zig
/// Represents an RGBA color where components are in 0-255 range
/// order: r, g, b, a
pub const Color = packed struct {
    r: u8,
    g: u8,
    b: u8,
    a: u8,
};
```

I assume the intention was to have a 32 bit field wit 4 components, given the explanation comment on top. If I misunderstood feel free to close the PR, although the comment would need to be updated then.