### PR TITLE
Fix callconv parameter

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -975,7 +975,7 @@ pub fn onHover(
 
     cdefs.Clay_OnHover(
         struct {
-            pub fn f(element_id: ElementId, pointer_data: PointerData, user_data_: ?*anyopaque) callconv(.C) void {
+            pub fn f(element_id: ElementId, pointer_data: PointerData, user_data_: ?*anyopaque) callconv(.c) void {
                 onHoverFunction(
                     element_id,
                     pointer_data,


### PR DESCRIPTION
Hey, 
thank you for creating these bindings to clay :).
I had encountered an issue when I wanted to use the OnHover functionality.

I am not that experienced with Zig so please don't accepts my PR blindy.

I could not compile the source code because of a faulty callconv. 
It seem that the parameter needs to be ".c" instead of ".C"