### PR TITLE
add: simple testing with `std.testing.refAllDeclsRecursive(@This());`

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -1,6 +1,10 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+test {
+    std.testing.refAllDeclsRecursive(@This());
+}
+
 pub extern var CLAY_LAYOUT_DEFAULT: LayoutConfig;
 
 /// Color used for highlighting elements with the debug inspector panel (can be modified directly)
@@ -218,7 +222,9 @@ pub const Padding = extern struct {
     /// Padding on bottom side
     bottom: u16 = 0,
 
-    pub const xy = @compileError("renamed to axes"); // TODO: remove this in v0.3.0
+    /// # DEPRECATED
+    /// Use .axes instead.
+    pub const xy = axes; // TODO: remove this in v0.3.0
 
     /// Padding with vertical and horizontal values
     pub fn axes(top_bottom: u16, left_right: u16) Padding {

--- a/src/root.zig
+++ b/src/root.zig
@@ -224,7 +224,10 @@ pub const Padding = extern struct {
 
     /// # DEPRECATED
     /// Use .axes instead.
-    pub const xy = axes; // TODO: remove this in v0.3.0
+    pub fn xy(top_bottom: u16, left_right: u16) Padding { // TODO: remove this in v0.3.0
+        std.log.warn("deprecated(Padding.xy): use Padding.axes instead", .{});
+        return axes(top_bottom, left_right);
+    }
 
     /// Padding with vertical and horizontal values
     pub fn axes(top_bottom: u16, left_right: u16) Padding {


### PR DESCRIPTION
Hey!
I have noticed that this library has no real testing implemented yet, so I have added the basic test of:
```zig
test {
    std.testing.refAllDeclsRecursive(@This());
}
```

This is just a band-aid fix, but it does the job well. The only problem was the deprecation of `Padding.xy` which threw a `compileError`, so I have changed that to be a wrapper of `Padding.axes` with an additional `std.log.warn` statement.

```zig
/// # DEPRECATED
/// Use .axes instead.
pub fn xy(top_bottom: u16, left_right: u16) Padding { // TODO: remove this in v0.3.0
    std.log.warn("deprecated(Padding.xy): use Padding.axes instead", .{});
    return axes(top_bottom, left_right);
}
```

I know this implementation is not perfect, but throwing a `compileError` can mess with modules which import this one. For example if a module has `zclay` imported and uses  `std.testing.refAllDeclsRecursive(@This());` for tests, `zclay` will always throw a `compileError` (this is how I found out about it in the first place). 