### PR TITLE
[WIP] Include renderer inside the library instead of explicitly providing them at project level

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,20 +55,8 @@ Compatible Zig Version: `0.15.1`
 zig fetch --save git+https://github.com/johan0A/clay-zig-bindings#v0.2.2+0.14
 ```
 
-2a. Config `build.zig`:
+2. Config `build.zig`:
 
-```zig
-...
-const zclay_dep = b.dependency("zclay", .{
-    .target = target,
-    .optimize = optimize,
-});
-
-compile_step.root_module.addImport("zclay", zclay_dep.module("zclay"));
-...
-```
-
-2b. Alternatively, if you use raylib-zig (or any future supported backends), you could do the following to load the corresponding dependencies for the binding:
 ```zig
 ...
 // you also need to install raylib-zig dependency if you use the raylib renderer
@@ -86,8 +74,20 @@ compile_step.root_module.addImport("zclay", zclay_dep.module("zclay"));
 ...
 ```
 
+- Alternatively, if you have written your own renderer for your own project, you could just ingore all the additional dependency loading:
+```zig
+...
+const zclay_dep = b.dependency("zclay", .{
+    .target = target,
+    .optimize = optimize,
+});
+
+compile_step.root_module.addImport("zclay", zclay_dep.module("zclay"));
+...
+```
+
 ## quickstart
-1. Before writing your first clay application, you need to import zclay and the renderer of your choice:
+1. Before writing your first clay application, you need to import zclay and the renderer of your choosing:
 
 ```zig
 // If you have chosen the renderer when you load clay as a dependency in build.zig (Raylib for example:)
@@ -110,7 +110,7 @@ _ = clay.initialize(arena, .{ .h = 1000, .w = 1000 }, .{});
 clay.setMeasureTextFunction(void, {}, renderer.measureText);
 ```
 
-3. Provide a `measureText(text, config)` function with [clay.setMeasureTextFunction(function)](https://github.com/nicbarker/clay/blob/main/README.md#clay_setmeasuretextfunction) so that clay can measure and wrap text.
+3. Provide a `measureText(text, config)` function with [clay.setMeasureTextFunction(function)](https://github.com/nicbarker/clay/blob/main/README.md#clay_setmeasuretextfunction) so that clay can measure and wrap text. If you use one of the default renderers in the library, you can simply call the function from the renderer without writing your own.
 
 ```zig
 // Example measure text function

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ compile_step.root_module.addImport("zclay", zclay_dep.module("zclay"));
 ```
 
 ## quickstart
-1. Before writing your first clay application, you need to import zclay and the renderer of your choosing:
+1. Before writing your first clay application, you need to import zclay and the renderer of your choice:
 
 ```zig
-// If you have chosen any the renderer when you load clay as a dependency in build.zig (Raylib for example:)
+// If you have chosen the renderer when you load clay as a dependency in build.zig (Raylib for example:)
 const cl = @import("zclay");
 const renderer = cl.renderer;
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Compatible Zig Version: `0.15.1`
 zig fetch --save git+https://github.com/johan0A/clay-zig-bindings#v0.2.2+0.14
 ```
 
-2. Config `build.zig`:
+2a. Config `build.zig`:
 
 ```zig
 ...
@@ -63,11 +63,41 @@ const zclay_dep = b.dependency("zclay", .{
     .target = target,
     .optimize = optimize,
 });
+
+compile_step.root_module.addImport("zclay", zclay_dep.module("zclay"));
+...
+```
+
+2b. Alternatively, if you use raylib-zig (or any future supported backends), you could do the following to load the corresponding dependencies for the binding:
+```zig
+...
+// you also need to install raylib-zig dependency if you use the raylib renderer
+// see: https://github.com/raylib-zig/raylib-zig?tab=readme-ov-file#building-and-using
+const raylib_dep = ...
+
+const zclay_dep = b.dependency("zclay", .{
+    .target = target,
+    .optimize = optimize,
+    .renderer = .raylib,
+});
+
+zclay_dep.module("zclay").addImport("raylib", raylib_dep.module("raylib"));
 compile_step.root_module.addImport("zclay", zclay_dep.module("zclay"));
 ...
 ```
 
 ## quickstart
+1. Before writing your first clay application, you need to import zclay and the renderer of your choosing:
+
+```zig
+// If you have chosen any the renderer when you load clay as a dependency in build.zig (Raylib for example:)
+const cl = @import("zclay");
+const renderer = cl.renderer;
+
+// If you don't, you need to import your own renderer:
+const cl = @import("zclay");
+const renderer = @import("raylib_render_clay.zig");
+```
 
 2. Ask clay for how much static memory it needs using [clay.minMemorySize()](https://github.com/nicbarker/clay/blob/main/README.md#clay_minmemorysize), create an Arena for it to use with [clay.createArenaWithCapacityAndMemory(minMemorySize, memory)](https://github.com/nicbarker/clay/blob/main/README.md#clay_createarenawithcapacityandmemory), and initialize it with [clay.Initialize(arena)](https://github.com/nicbarker/clay/blob/main/README.md#clay_initialize).
 

--- a/build.zig
+++ b/build.zig
@@ -1,14 +1,33 @@
 const std = @import("std");
 const B = std.Build;
 
+const Renderer = enum {
+    custom,
+    raylib,
+};
+
 pub fn build(b: *B) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+
+    const options = .{
+        .renderer = b.option(Renderer, "renderer", "Renderer to build (default: custom renderer)") orelse .custom,
+    };
+
+    const options_step = b.addOptions();
+    inline for (std.meta.fields(@TypeOf(options))) |field| {
+        options_step.addOption(field.type, field.name, @field(options, field.name));
+    }
+
+    const options_module = options_step.createModule();
 
     const root_module = b.addModule("zclay", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{ .name = "zclay_options", .module = options_module },
+        },
     });
 
     {

--- a/examples/raylib-sidebar-container/build.zig
+++ b/examples/raylib-sidebar-container/build.zig
@@ -12,18 +12,21 @@ pub fn build(b: *B) void {
         .optimize = optimize,
     });
 
-    const zclay_dep = b.dependency("zclay", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    root_module.addImport("zclay", zclay_dep.module("zclay"));
-
     const raylib_dep = b.dependency("raylib_zig", .{
         .target = target,
         .optimize = optimize,
     });
     root_module.addImport("raylib", raylib_dep.module("raylib"));
     root_module.linkLibrary(raylib_dep.artifact("raylib"));
+
+    const zclay_dep = b.dependency("zclay", .{
+        .target = target,
+        .optimize = optimize,
+        .renderer = .raylib,
+    });
+
+    zclay_dep.module("zclay").addImport("raylib", raylib_dep.module("raylib"));
+    root_module.addImport("zclay", zclay_dep.module("zclay"));
 
     {
         const exe = b.addExecutable(.{ .name = "zclay-example", .root_module = root_module });

--- a/examples/raylib-sidebar-container/src/main.zig
+++ b/examples/raylib-sidebar-container/src/main.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const rl = @import("raylib");
 const cl = @import("zclay");
-const renderer = @import("raylib_render_clay.zig");
+const renderer = cl.renderer;
 
 const light_grey: cl.Color = .{ 224, 215, 210, 255 };
 const red: cl.Color = .{ 168, 66, 28, 255 };

--- a/src/renderers/raylib_render_clay.zig
+++ b/src/renderers/raylib_render_clay.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const rl = @import("raylib");
-const cl = @import("zclay");
+const cl = @import("../root.zig");
 const math = std.math;
 
 pub fn clayColorToRaylibColor(color: cl.Color) rl.Color {

--- a/src/root.zig
+++ b/src/root.zig
@@ -5,6 +5,11 @@ test {
     std.testing.refAllDeclsRecursive(@This());
 }
 
+pub const renderer = switch (@import("zclay_options").renderer) {
+    .custom => .{},
+    .raylib => @import("renderers/raylib_render_clay.zig"),
+};
+
 pub extern var CLAY_LAYOUT_DEFAULT: LayoutConfig;
 
 /// Color used for highlighting elements with the debug inspector panel (can be modified directly)


### PR DESCRIPTION
As suggested [previously](https://github.com/johan0A/clay-zig-bindings/issues/16), I was thinking of putting the renderer backend inside the library so that users can use the library out of the box by selecting a preferred backend along with the related dependency instead of providing the renderer from their ends.

So far, I have gotten a working solution, and all you need is to choose a renderer at build.zig in your projects as shown:
 
``` zig
const raylib_dep = b.dependency("raylib_zig", .{
	.target = target,
	.optimize = optimize,
});
root_module.addImport("raylib", raylib_dep.module("raylib"));
root_module.linkLibrary(raylib_dep.artifact("raylib"));

const zclay_dep = b.dependency("zclay", .{
	.target = target,
	.optimize = optimize,
	.renderer = .raylib,
});

// if you use custom renderer from your projects, skip the addImport function
zclay_dep.module("zclay").addImport("raylib", raylib_dep.module("raylib"));
root_module.addImport("zclay", zclay_dep.module("zclay"));
```

At the application level, instead of loading your renderer file, all you need is to fetch the renderer from the zclay module as shown:

``` zig
const cl = @import("zclay");
const renderer = cl.renderer;
```

This works because under the hood, the library picks and selectively compile the renderer based on the switch statement, controlled by the .renderer option:

``` zig
pub const renderer = switch (@import("zclay_options").renderer) {
    .custom => .{},
    .raylib => @import("renderers/raylib_render_clay.zig"),
};
```

Where the `@import("zclay_options").renderer` is an enum defined in the build.zig of the library:

``` zig
const Renderer = enum {
    custom,
    raylib,
};
```

As you can see, with this implementation, for every new backend added into the library, the contributors can simply add a new name into the enum and loading their renderer at root.zig by expending the switch statement with their imports.

To test the upgrade, you may build the example `raylib-sidebar-container` from my fork to see how the new option behaves and to verify the result. I didn't update `raylib-clay-official-website` because I want to show you that the original method still works so that it offers a way for users to test and build their own renderer.

I am a bit tired now, so my speaking is a bit incoherent. Please let me know if you have any questions.